### PR TITLE
fix: exclude painting images from content source to fix image loading

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,6 +22,7 @@ module.exports = {
       options: {
         name: `content`,
         path: `${__dirname}/content`,
+        ignore: [`**/paintings/images/**`],
       },
     },
     // Source painting images


### PR DESCRIPTION
The content source filesystem was sourcing files from /content/paintings/images/
before the paintingImages source could claim them, causing images to be assigned
sourceInstanceName: "content" instead of "paintingImages". This broke the GraphQL
queries that filter by sourceInstanceName: "paintingImages".

Adding an ignore pattern ensures the paintingImages source is the sole owner of
these image files.