### PR TITLE
fix: prevent white screen when clicking same-page links

### DIFF
--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -11,6 +11,20 @@ const getPathPrefix = (): string => {
   return prefixedRoot.length > 1 ? prefixedRoot.slice(0, -1) : ''
 }
 
+// Normalize a path by stripping the path prefix and trailing slash
+const normalizePath = (path: string): string => {
+  const pathPrefix = getPathPrefix()
+  let normalized =
+    pathPrefix && path.startsWith(pathPrefix)
+      ? path.slice(pathPrefix.length) || '/'
+      : path
+  // Remove trailing slash (except for root)
+  if (normalized !== '/' && normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1)
+  }
+  return normalized
+}
+
 // Must match --transition-fast in global.css
 const TRANSITION_DURATION = 500
 
@@ -79,17 +93,14 @@ const PageTransition: React.FC<PageTransitionProps> = ({ children }) => {
       // Don't handle if modifier keys are pressed
       if (e.metaKey || e.ctrlKey || e.shiftKey) return
 
-      // Strip path prefix for comparison and navigation
+      // Normalize both paths for comparison (strips prefix and trailing slash)
       // In production, href includes prefix (e.g., /lulutracy.com/about)
       // but navigate() expects path without prefix (e.g., /about)
-      const pathPrefix = getPathPrefix()
-      const normalizedHref =
-        pathPrefix && href.startsWith(pathPrefix)
-          ? href.slice(pathPrefix.length) || '/'
-          : href
+      const normalizedHref = normalizePath(href)
+      const normalizedCurrentPath = normalizePath(location.pathname)
 
       // Don't handle same-page links
-      if (normalizedHref === location.pathname) return
+      if (normalizedHref === normalizedCurrentPath) return
 
       e.preventDefault()
       setIsVisible(false)

--- a/src/components/__tests__/PageTransition.test.tsx
+++ b/src/components/__tests__/PageTransition.test.tsx
@@ -315,5 +315,77 @@ describe('PageTransition', () => {
       // Should navigate with original path
       expect(mockNavigate).toHaveBeenCalledWith('/about')
     })
+
+    it('does not intercept same-page links when location.pathname includes prefix', () => {
+      // Simulate production environment where location.pathname includes the path prefix
+      renderWithLocation(
+        <PageTransition>
+          <a href="/lulutracy.com/about">About</a>
+        </PageTransition>,
+        '/lulutracy.com/about'
+      )
+
+      act(() => {
+        jest.advanceTimersByTime(50)
+      })
+
+      const link = screen.getByText('About')
+      fireEvent.click(link)
+
+      // Should not navigate for same-page links (even with prefix in pathname)
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('does not intercept same-page links with trailing slash differences', () => {
+      // Simulate case where href has no trailing slash but pathname does
+      renderWithLocation(
+        <PageTransition>
+          <a href="/lulutracy.com/about">About</a>
+        </PageTransition>,
+        '/lulutracy.com/about/'
+      )
+
+      act(() => {
+        jest.advanceTimersByTime(50)
+      })
+
+      const link = screen.getByText('About')
+      fireEvent.click(link)
+
+      // Should not navigate for same-page links (even with trailing slash difference)
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('does not intercept same-page links at root with prefix', () => {
+      // Simulate clicking logo on homepage in production
+      renderWithLocation(
+        <PageTransition>
+          <a href="/lulutracy.com/">Home</a>
+        </PageTransition>,
+        '/lulutracy.com/'
+      )
+
+      act(() => {
+        jest.advanceTimersByTime(50)
+      })
+
+      const link = screen.getByText('Home')
+      fireEvent.click(link)
+
+      // Should not navigate for same-page links
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
The page transition was fading out but never fading back in when
clicking links that navigate to the current page (e.g., logo on
homepage, About link when on About page).

Root cause: The same-page link detection compared normalized href
(without path prefix) against location.pathname (with path prefix
in production), causing the check to fail.

Fix: Added a normalizePath helper that strips both the path prefix
and trailing slash from paths, and use it to normalize both the
href and current pathname for comparison.

Also added tests for:
- Same-page links with path prefix in pathname
- Same-page links with trailing slash differences
- Root path same-page links with prefix