### PR TITLE
build: add makefile targets for e2e tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Gatsby-based art portfolio with i18n (en, zh, yue, ms), dark mode, and image mag
 make dev          # Dev server at localhost:8000
 make build        # Production build
 make test         # Run tests
+make e2e          # Run e2e tests (Playwright)
 make lint         # Check linting
 make typecheck    # TypeScript checks
 make validate     # All checks (lint, typecheck, format, test)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: help install dev build build-prod serve serve-prod clean test test-watch test-coverage \
         lint lint-fix format format-check typecheck validate ci ci-fast lighthouse \
-        prepare hooks-install
+        prepare hooks-install e2e e2e-ui e2e-headed e2e-install e2e-report
 
 # Default target
 .DEFAULT_GOAL := help
@@ -25,7 +25,7 @@ help: ## Show this help message
 	@echo "$(GREEN)Usage:$(RESET) make [target]"
 	@echo ""
 	@echo "$(YELLOW)Development:$(RESET)"
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(GREEN)%-15s$(RESET) %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(GREEN)%-15s$(RESET) %s\n", $$1, $$2}'
 
 #------------------------------------------------------------------------------
 # Setup & Installation
@@ -97,6 +97,25 @@ test-watch: ## Run tests in watch mode
 
 test-coverage: ## Run tests with coverage report
 	npm run test:coverage
+
+#------------------------------------------------------------------------------
+# E2E Testing (Playwright)
+#------------------------------------------------------------------------------
+
+e2e-install: ## Install Playwright browsers
+	npx playwright install --with-deps
+
+e2e: ## Run e2e tests
+	npm run test:e2e
+
+e2e-ui: ## Run e2e tests with interactive UI
+	npm run test:e2e:ui
+
+e2e-headed: ## Run e2e tests in headed browser mode
+	npm run test:e2e:headed
+
+e2e-report: ## Show Playwright test report
+	npx playwright show-report
 
 #------------------------------------------------------------------------------
 # Validation & CI


### PR DESCRIPTION
Add Playwright e2e testing targets to Makefile:
- e2e: run e2e tests
- e2e-ui: run with interactive UI
- e2e-headed: run in headed browser mode
- e2e-install: install Playwright browsers
- e2e-report: show test report

Also fix help regex to support targets with digits (e2e).