### PR TITLE
ci: migrate from github pages to cloudflare pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches-ignore: [main]
     paths-ignore:
       - '**.md'
       - '.claude/**'
@@ -20,40 +20,28 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 env:
   NODE_VERSION: '20'
 
 jobs:
-  # Single job approach - faster for small/medium projects
-  # Avoids: 3x job startup overhead (~30s), 3x npm ci (~60s), artifact transfer
   ci:
     name: CI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-
-      # Cache node_modules directly - much faster than npm cache alone
-      # npm ci with warm cache: ~25s, cached node_modules restore: ~5s
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      # Run lint, format, typecheck in parallel (all are fast, read-only)
+      # Run lint, format, typecheck in parallel
       - name: Lint, Format & Typecheck
         run: |
           npm run typecheck &
@@ -70,95 +58,3 @@ jobs:
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
-
-      # Cache Gatsby build artifacts - exact match only (no restore-keys fallback)
-      # This ensures fresh builds when any source changes, while still benefiting
-      # from cache hits on rebuild/retry scenarios
-      # Note: restore-keys intentionally omitted - Gatsby's cache invalidation
-      # doesn't track GraphQL query changes, causing stale image issues
-      - name: Cache Gatsby
-        uses: actions/cache@v4
-        with:
-          path: |
-            .cache
-            public
-          key: gatsby-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('gatsby-config.js', 'gatsby-node.js') }}-${{ hashFiles('content/**') }}-${{ hashFiles('src/**') }}
-          # No restore-keys - exact match only for correctness
-
-      - name: Build
-        run: npm run build
-        env:
-          GATSBY_CPU_COUNT: 4
-          NODE_OPTIONS: '--max-old-space-size=4096'
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: build
-          path: ./public
-          retention-days: 1
-
-  # Lighthouse runs after CI, reuses build artifact (no duplicate build)
-  # Only runs on PRs - not needed for direct pushes to main
-  lighthouse:
-    name: Lighthouse
-    runs-on: ubuntu-latest
-    needs: ci
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Download build artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: build
-          path: ./public
-
-      - name: Run Lighthouse
-        uses: treosh/lighthouse-ci-action@v12
-        with:
-          configPath: ./lighthouserc.js
-          uploadArtifacts: true
-          temporaryPublicStorage: true
-
-      - name: Post Lighthouse scores
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const fs = require('fs');
-            const results = JSON.parse(fs.readFileSync('.lighthouseci/manifest.json'));
-
-            // Aggregate scores by URL (average of multiple runs)
-            const scores = {};
-            for (const result of results) {
-              const summary = JSON.parse(fs.readFileSync(result.jsonPath));
-              const url = new URL(summary.finalUrl).pathname.replace(/index\.html$/, '') || '/';
-
-              if (!scores[url]) {
-                scores[url] = { perf: [], a11y: [], bp: [], seo: [] };
-              }
-              scores[url].perf.push(summary.categories.performance.score * 100);
-              scores[url].a11y.push(summary.categories.accessibility.score * 100);
-              scores[url].bp.push(summary.categories['best-practices'].score * 100);
-              scores[url].seo.push(summary.categories.seo.score * 100);
-            }
-
-            const avg = arr => Math.round(arr.reduce((a, b) => a + b, 0) / arr.length);
-            const getEmoji = score => score >= 90 ? '🟢' : score >= 50 ? '🟡' : '🔴';
-
-            let comment = '## Lighthouse Results\n\n';
-            comment += '| Page | Performance | Accessibility | Best Practices | SEO |\n';
-            comment += '|------|-------------|---------------|----------------|-----|\n';
-
-            for (const [url, s] of Object.entries(scores)) {
-              const perf = avg(s.perf), a11y = avg(s.a11y), bp = avg(s.bp), seo = avg(s.seo);
-              comment += `| ${url} | ${getEmoji(perf)} ${perf} | ${getEmoji(a11y)} ${a11y} | ${getEmoji(bp)} ${bp} | ${getEmoji(seo)} ${seo} |\n`;
-            }
-
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: comment
-            });

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy to Cloudflare Pages
 
 on:
   push:
@@ -7,52 +7,35 @@ on:
       - '**.md'
       - '.claude/**'
       - 'LICENSE'
+  pull_request:
+    branches: [main]
   workflow_dispatch:
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
 
 env:
   NODE_VERSION: '20'
 
 jobs:
-  # Combined CI + Build job - eliminates redundant npm ci calls and job overhead
-  build:
-    name: Build & Test
+  build-and-deploy:
+    name: Build & Deploy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-
-      # Cache node_modules directly - skip npm ci on cache hit
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-        with:
-          static_site_generator: gatsby
+          cache: 'npm'
 
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      # Run all checks in parallel
+      # Run validation checks
       - name: Lint, Format & Typecheck
         run: |
           npm run typecheck &
@@ -80,24 +63,12 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          PREFIX_PATHS: 'true'
           GATSBY_CPU_COUNT: 4
           NODE_OPTIONS: '--max-old-space-size=4096'
-          GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES: 'true'
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
         with:
-          path: ./public
-
-  deploy:
-    name: Deploy
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy public --project-name=lulutracy --commit-dirty=true

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,23 +1,24 @@
 /**
  * @type {import('gatsby').GatsbyConfig}
  */
+const siteUrl = process.env.SITE_URL || `https://lulutracy.pages.dev`
+
 module.exports = {
   siteMetadata: {
     title: `lulutracy`,
     description: `Art portfolio of lulutracy - exploring nature through watercolors and acrylics`,
     author: `lulutracy`,
-    siteUrl: `https://our-nature.github.io/lulutracy.com`,
+    siteUrl,
     supportedLanguages: ['en', 'zh', 'yue', 'ms'],
     defaultLanguage: 'en',
   },
-  pathPrefix: process.env.PREFIX_PATHS === 'true' ? `/lulutracy.com` : ``,
   plugins: [
     {
       resolve: `gatsby-plugin-sitemap`,
       options: {
-        resolveSiteUrl: () => `https://our-nature.github.io/lulutracy.com`,
+        resolveSiteUrl: () => siteUrl,
         serialize: ({ path }) => ({
-          url: `https://our-nature.github.io/lulutracy.com${path}`,
+          url: `${siteUrl}${path}`,
           changefreq: `weekly`,
           priority: path === `/` ? 1.0 : 0.7,
         }),
@@ -93,7 +94,7 @@ module.exports = {
         languages: ['en', 'zh', 'yue', 'ms'],
         defaultLanguage: 'en',
         generateDefaultLanguagePages: true,
-        siteUrl: `https://our-nature.github.io/lulutracy.com`,
+        siteUrl,
         i18nextOptions: {
           interpolation: {
             escapeValue: false,


### PR DESCRIPTION
- Update gatsby-config.js to use configurable SITE_URL env var
- Remove GitHub Pages pathPrefix logic (not needed for CF)
- Replace deploy.yml with Cloudflare Pages deployment via wrangler
- Simplify ci.yml to run only validation (no build/deploy)
- Enable automatic preview URLs for PRs via Cloudflare Pages

BREAKING CHANGE: Requires CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID
secrets to be configured in GitHub repository settings.