### PR TITLE
Fix mobile dropdown menu text alignment

### DIFF
--- a/src/components/LanguageSwitcher.module.css
+++ b/src/components/LanguageSwitcher.module.css
@@ -73,6 +73,10 @@
 
 /* Mobile: left-align dropdown in mobile menu */
 @media (max-width: 767px) {
+  .trigger {
+    padding-left: 0;
+  }
+
   .dropdown {
     left: 0;
     right: auto;


### PR DESCRIPTION
- Add media query for mobile devices (max-width: 767px)
- Change language dropdown from right-aligned to left-aligned on mobile
- Keep about link left-aligned as before
- Desktop view remains right-aligned